### PR TITLE
fix: パンくずリストの構造化データマークアップを修正

### DIFF
--- a/.output.txt
+++ b/.output.txt
@@ -1,520 +1,350 @@
-本番（ビルド）環境用設定に切り替え中...
-アプリケーションを bundle 中
-   0. 0s  INFO Bundling project...
-   0.124s  INFO Building app...
-   0.633s  INFO Compiling [  1/290]: build-script-build
-   0.633s  INFO Compiling [  3/290]: unicode_ident
-   0.633s  INFO Compiling [  4/290]: autocfg
-   0.633s  INFO Compiling [  5/290]: cfg_if
-   0.633s  INFO Compiling [  6/290]: build-script-build
-   0.633s  INFO Compiling [  7/290]: once_cell
-   0.634s  INFO Compiling [  8/290]: version_check
-   0.634s  INFO Compiling [  9/290]: pin_project_lite
-   0.634s  INFO Compiling [ 10/290]: futures_core
-   0.634s  INFO Compiling [ 11/290]: memchr
-   0.634s  INFO Compiling [ 12/290]: futures_sink
-   0.634s  INFO Compiling [ 13/290]: pin_utils
-   0.634s  INFO Compiling [ 14/290]: futures_task
-   0.634s  INFO Compiling [ 15/290]: futures_io
-   0.634s  INFO Compiling [ 16/290]: build-script-build
-   0.634s  INFO Compiling [ 17/290]: log
-   0.634s  INFO Compiling [ 18/290]: smallvec
-   0.634s  INFO Compiling [ 19/290]: itoa
-   0.634s  INFO Compiling [ 20/290]: bytes
-   0.634s  INFO Compiling [ 21/290]: unicode_xid
-   0.634s  INFO Compiling [ 22/290]: build-script-build
-   0.634s  INFO Compiling [ 23/290]: scopeguard
-   0.634s  INFO Compiling [ 24/290]: build-script-build
-   0.634s  INFO Compiling [ 25/290]: fnv
-   0.634s  INFO Compiling [ 26/290]: proc_macro2
-   0.635s  INFO Compiling [ 28/290]: build-script-build
-   0.635s  INFO Compiling [ 29/290]: futures_channel
-   0.635s  INFO Compiling [ 31/290]: tracing_core
-   0.635s  INFO Compiling [ 32/290]: build-script-build
-   0.635s  INFO Compiling [ 34/290]: http
-   0.635s  INFO Compiling [ 36/290]: stable_deref_trait
-   0.635s  INFO Compiling [ 37/290]: build-script-build
-   0.635s  INFO Compiling [ 38/290]: dioxus_core_types
-   0.635s  INFO Compiling [ 39/290]: build-script-build
-   0.635s  INFO Compiling [ 40/290]: build-script-main
-   0.635s  INFO Compiling [ 41/290]: build-script-build
-   0.635s  INFO Compiling [ 42/290]: byteorder
-   0.635s  INFO Compiling [ 43/290]: rustc_hash
-   0.635s  INFO Compiling [ 44/290]: build-script-build
-   0.635s  INFO Compiling [ 45/290]: longest_increasing_subsequence
-   0.635s  INFO Compiling [ 46/290]: log
-   0.635s  INFO Compiling [ 47/290]: build-script-build
-   0.635s  INFO Compiling [ 48/290]: unicode_segmentation
-   0.635s  INFO Compiling [ 49/290]: build-script-build
-   0.635s  INFO Compiling [ 50/290]: quote
-   0.635s  INFO Compiling [ 51/290]: libc
-   0.635s  INFO Compiling [ 54/290]: rustversion
-   0.635s  INFO Compiling [ 59/290]: bumpalo
-   0.636s  INFO Compiling [ 62/290]: convert_case
-   0.636s  INFO Compiling [ 63/290]: ryu
-   0.636s  INFO Compiling [ 64/290]: build-script-build
-   0.636s  INFO Compiling [ 65/290]: writeable
-   0.636s  INFO Compiling [ 66/290]: fnv
-   0.636s  INFO Compiling [ 67/290]: build-script-build
-   0.636s  INFO Compiling [ 68/290]: ident_case
-   0.636s  INFO Compiling [ 69/290]: litemap
-   0.636s  INFO Compiling [ 70/290]: build-script-build
-   0.636s  INFO Compiling [ 71/290]: build-script-build
-   0.636s  INFO Compiling [ 72/290]: percent_encoding
-   0.636s  INFO Compiling [ 73/290]: syn
-   0.636s  INFO Compiling [ 74/290]: slab
-   0.636s  INFO Compiling [ 75/290]: const_format_proc_macros
-   0.636s  INFO Compiling [ 76/290]: lock_api
-   0.636s  INFO Compiling [ 77/290]: parking_lot_core
-   0.636s  INFO Compiling [ 78/290]: wasm_bindgen_shared
-   0.636s  INFO Compiling [ 79/290]: typenum
-   0.636s  INFO Compiling [ 80/290]: socket2
-   0.636s  INFO Compiling [ 81/290]: mio
-   0.636s  INFO Compiling [ 82/290]: getrandom
-   0.637s  INFO Compiling [ 83/290]: httparse
-   0.637s  INFO Compiling [ 86/290]: lazy_js_bundle
-   0.637s  INFO Compiling [ 90/290]: http_body
-   0.637s  INFO Compiling [ 92/290]: tower_service
-   0.637s  INFO Compiling [ 93/290]: cpufeatures
-   0.637s  INFO Compiling [ 94/290]: unicode_ident
-   0.637s  INFO Compiling [ 95/290]: tower_layer
-   0.637s  INFO Compiling [ 96/290]: serde_derive
-   0.637s  INFO Compiling [ 97/290]: futures_macro
-   0.637s  INFO Compiling [ 98/290]: tracing_attributes
-   0.637s  INFO Compiling [ 99/290]: synstructure
-   0.637s  INFO Compiling [100/290]: pin_project_internal
-   0.637s  INFO Compiling [101/290]: zerovec_derive
-   0.637s  INFO Compiling [102/290]: const_format
-   0.637s  INFO Compiling [103/290]: parking_lot
-   0.637s  INFO Compiling [104/290]: warnings_macro
-   0.637s  INFO Compiling [105/290]: displaydoc
-   0.637s  INFO Compiling [106/290]: zerocopy_derive
-   0.637s  INFO Compiling [107/290]: generic_array
-   0.638s  INFO Compiling [108/290]: wasm_bindgen_backend
-   0.638s  INFO Compiling [109/290]: thiserror_impl
-   0.638s  INFO Compiling [110/290]: tokio_macros
-   0.638s  INFO Compiling [111/290]: darling_core
-   0.638s  INFO Compiling [112/290]: rand_core
-   0.638s  INFO Compiling [113/290]: num_traits
-   0.638s  INFO Compiling [114/290]: icu_properties_data
-   0.638s  INFO Compiling [115/290]: proc_macro2_diagnostics
-   0.638s  INFO Compiling [116/290]: icu_normalizer_data
-   0.638s  INFO Compiling [117/290]: proc_macro2
-   0.638s  INFO Compiling [118/290]: utf8
-   0.638s  INFO Compiling [119/290]: futures_util
-   0.638s  INFO Compiling [120/290]: serde
-   0.638s  INFO Compiling [121/290]: tracing
-   0.638s  INFO Compiling [122/290]: pin_project
-   0.638s  INFO Compiling [123/290]: zerofrom_derive
-   0.638s  INFO Compiling [124/290]: yoke_derive
-   0.638s  INFO Compiling [125/290]: zerocopy
-   0.638s  INFO Compiling [126/290]: thiserror
-   0.639s  INFO Compiling [127/290]: tokio
-   0.639s  INFO Compiling [128/290]: wasm_bindgen_macro_support
-   0.639s  INFO Compiling [129/290]: block_buffer
-   0.639s  INFO Compiling [130/290]: crypto_common
-   0.639s  INFO Compiling [131/290]: darling_macro
-   0.639s  INFO Compiling [132/290]: bitflags
-   0.639s  INFO Compiling [133/290]: mime
-   0.639s  INFO Compiling [134/290]: data_encoding
-   0.639s  INFO Compiling [135/290]: quote
-   0.639s  INFO Compiling [136/290]: dioxus_rsx
-   0.639s  INFO Compiling [137/290]: const_serialize_macro
-   0.639s  INFO Compiling [138/290]: form_urlencoded
-   0.639s  INFO Compiling [139/290]: httpdate
-   0.639s  INFO Compiling [140/290]: build-script-build
-   0.639s  INFO Compiling [141/290]: euclid
-   0.639s  INFO Compiling [142/290]: zerofrom
-   0.639s  INFO Compiling [143/290]: warnings
-   0.639s  INFO Compiling [144/290]: slotmap
-   0.639s  INFO Compiling [145/290]: generational_box
-   0.640s  INFO Compiling [146/290]: ppv_lite86
-   0.640s  INFO Compiling [147/290]: wasm_bindgen_macro
-   0.640s  INFO Compiling [148/290]: digest
-   0.640s  INFO Compiling [149/290]: darling
-   0.640s  INFO Compiling [150/290]: syn
-   0.640s  INFO Compiling [152/290]: keyboard_types
-   0.640s  INFO Compiling [153/290]: dioxus_core_macro
-   0.640s  INFO Compiling [154/290]: http_body_util
-   0.640s  INFO Compiling [155/290]: build-script-build
-   0.640s  INFO Compiling [156/290]: const_format
-   0.640s  INFO Compiling [157/290]: dioxus_html_internal_macro
-   0.640s  INFO Compiling [159/290]: build-script-build
-   0.640s  INFO Compiling [160/290]: sync_wrapper
-   0.640s  INFO Compiling [161/290]: dioxus_cli_config
-   0.640s  INFO Compiling [162/290]: utf8_iter
-   0.640s  INFO Compiling [163/290]: xxhash_rust
-   0.640s  INFO Compiling [164/290]: unicase
-   0.640s  INFO Compiling [165/290]: yoke
-   0.640s  INFO Compiling [166/290]: dioxus_core
-   0.640s  INFO Compiling [167/290]: rand_chacha
-   0.640s  INFO Compiling [168/290]: wasm_bindgen
-   0.641s  INFO Compiling [169/290]: sha1
-   0.641s  INFO Compiling [170/290]: enumset_derive
-   0.641s  INFO Compiling [171/290]: build-script-build
-   0.641s  INFO Compiling [172/290]: proc_macro2_diagnostics
-   0.641s  INFO Compiling [173/290]: serde
-   0.641s  INFO Compiling [174/290]: server_fn_macro
-   0.641s  INFO Compiling [177/290]: hyper
-   0.641s  INFO Compiling [178/290]: async_trait
-   0.641s  INFO Compiling [179/290]: encoding_rs
-   0.641s  INFO Compiling [180/290]: build-script-build
-   0.641s  INFO Compiling [181/290]: allocator_api2
-   0.641s  INFO Compiling [182/290]: equivalent
-   0.641s  INFO Compiling [183/290]: spin
-   0.641s  INFO Compiling [184/290]: foldhash
-   0.641s  INFO Compiling [185/290]: tower
-   0.641s  INFO Compiling [186/290]: serde_urlencoded
-   0.641s  INFO Compiling [187/290]: serde_path_to_error
-   0.642s  INFO Compiling [188/290]: zerovec
-   0.642s  INFO Compiling [189/290]: zerotrie
-   0.642s  INFO Compiling [190/290]: rand
-   0.642s  INFO Compiling [191/290]: dioxus_signals
-   0.642s  INFO Compiling [192/290]: js_sys
-   0.642s  INFO Compiling [193/290]: enumset
-   0.642s  INFO Compiling [194/290]: const_serialize
-   0.642s  INFO Compiling [195/290]: dioxus_rsx
-   0.642s  INFO Compiling [197/290]: dioxus_history
-   0.642s  INFO Compiling [199/290]: multer
-   0.642s  INFO Compiling [200/290]: hyper_util
-   0.642s  INFO Compiling [201/290]: axum_core
-   0.642s  INFO Compiling [202/290]: hashbrown
-   0.642s  INFO Compiling [203/290]: tokio_util
-   0.642s  INFO Compiling [204/290]: futures_executor
-   0.642s  INFO Compiling [205/290]: axum_macros
-   0.642s  INFO Compiling [206/290]: build-script-build
-   0.642s  INFO Compiling [207/290]: dioxus_config_macro
-   0.642s  INFO Compiling [209/290]: half
-   0.642s  INFO Compiling [210/290]: base64
-   0.642s  INFO Compiling [211/290]: tinystr
-   0.642s  INFO Compiling [212/290]: potential_utf
-   0.642s  INFO Compiling [213/290]: dioxus_hooks
-   0.642s  INFO Compiling [214/290]: tungstenite
-   0.643s  INFO Compiling [215/290]: wasm_bindgen_futures
-   0.643s  INFO Compiling [216/290]: hashbrown
-   0.643s  INFO Compiling [217/290]: lazy_static
-   0.643s  INFO Compiling [218/290]: matchit
-   0.643s  INFO Compiling [219/290]: unicase
-   0.643s  INFO Compiling [220/290]: ciborium_io
-   0.643s  INFO Compiling [221/290]: iana_time_zone
-   0.643s  INFO Compiling [222/290]: lru
-   0.643s  INFO Compiling [224/290]: getrandom
-   0.643s  INFO Compiling [225/290]: tungstenite
-   0.643s  INFO Compiling [226/290]: futures
-   0.643s  INFO Compiling [227/290]: slab
-   0.643s  INFO Compiling [228/290]: manganis_core
-   0.643s  INFO Compiling [229/290]: server_fn_macro_default
-   0.643s  INFO Compiling [230/290]: dioxus_devtools_types
-   0.643s  INFO Compiling [231/290]: tower
-   0.643s  INFO Compiling [232/290]: serde_qs
-   0.644s  INFO Compiling [233/290]: icu_locale_core
-   0.644s  INFO Compiling [234/290]: icu_collections
-   0.644s  INFO Compiling [235/290]: dioxus_html
-   0.644s  INFO Compiling [236/290]: tokio_tungstenite
-   0.644s  INFO Compiling [237/290]: ciborium_ll
-   0.644s  INFO Compiling [238/290]: chrono
-   0.644s  INFO Compiling [239/290]: dashmap
-   0.644s  INFO Compiling [240/290]: sharded_slab
-   0.644s  INFO Compiling [241/290]: mime_guess
-   0.644s  INFO Compiling [242/290]: const_serialize
-   0.644s  INFO Compiling [243/290]: send_wrapper
-   0.644s  INFO Compiling [244/290]: thread_local
-   0.644s  INFO Compiling [245/290]: inventory
-   0.644s  INFO Compiling [246/290]: askama_escape
-   0.644s  INFO Compiling [247/290]: xxhash_rust
-   0.644s  INFO Compiling [248/290]: http_range_header
-   0.644s  INFO Compiling [249/290]: dioxus_router_macro
-   0.644s  INFO Compiling [250/290]: dioxus_interpreter_js
-   0.645s  INFO Compiling [251/290]: rand_core
-   0.645s  INFO Compiling [252/290]: manganis_macro
-   0.645s  INFO Compiling [253/290]: tokio_stream
-   0.645s  INFO Compiling [254/290]: dioxus_server_macro
-   0.645s  INFO Compiling [255/290]: icu_provider
-   0.645s  INFO Compiling [256/290]: tracing_subscriber
-   0.645s  INFO Compiling [257/290]: dioxus_isrg
-   0.645s  INFO Compiling [258/290]: ciborium
-   0.645s  INFO Compiling [259/290]: dioxus_ssr
-   0.645s  INFO Compiling [260/290]: manganis_core
-   0.645s  INFO Compiling [261/290]: tower_http
-   0.645s  INFO Compiling [262/290]: tracing_futures
-   0.645s  INFO Compiling [263/290]: urlencoding
-   0.645s  INFO Compiling [264/290]: rand_chacha
-   0.645s  INFO Compiling [265/290]: either
-   0.645s  INFO Compiling [266/290]: icu_normalizer
-   0.645s  INFO Compiling [267/290]: icu_properties
-   0.646s  INFO Compiling [268/290]: manganis
-   0.646s  INFO Compiling [269/290]: dioxus_logger
-   0.646s  INFO Compiling [270/290]: rand
-   0.646s  INFO Compiling [271/290]: itertools
-   0.646s  INFO Compiling [272/290]: idna_adapter
-   0.646s  INFO Compiling [273/290]: idna
-   0.646s  INFO Compiling [274/290]: url
-   0.697s  INFO Compiling [275/290]: build-script-build
-   1.379s  INFO Compiling [277/290]: dioxus_devtools
-   1.414s  INFO Compiling [278/290]: serde_json
-   1.473s  INFO Compiling [279/290]: dioxus_lib
-   1.662s  INFO Compiling [280/290]: dioxus_document
-   1.958s  INFO Compiling [281/290]: dioxus_router
-   3.357s  INFO Compiling [282/290]: gloo_utils
-   3.471s  INFO Compiling [283/290]: web_sys
-   3.604s  INFO Compiling [284/290]: axum
-   3.700s  INFO Compiling [285/290]: gloo_net
-   3.818s  INFO Compiling [286/290]: wasm_streams
-   4.125s  INFO Compiling [287/290]: server_fn
-   4.614s  INFO Compiling [288/290]: dioxus
-   5.653s  INFO Compiling [289/290]: dioxus_fullstack
-   9.278s  INFO Compiling [  1/225]: build-script-build
-   9.278s  INFO Compiling [  3/225]: unicode_ident
-   9.279s  INFO Compiling [  4/225]: cfg_if
-   9.279s  INFO Compiling [  5/225]: once_cell
-   9.279s  INFO Compiling [  6/225]: autocfg
-   9.279s  INFO Compiling [  7/225]: build-script-build
-   9.279s  INFO Compiling [  8/225]: bumpalo
-   9.279s  INFO Compiling [  9/225]: log
-   9.279s  INFO Compiling [ 10/225]: build-script-build
-   9.279s  INFO Compiling [ 11/225]: build-script-build
-   9.279s  INFO Compiling [ 12/225]: version_check
-   9.279s  INFO Compiling [ 13/225]: pin_project_lite
-   9.279s  INFO Compiling [ 14/225]: smallvec
-   9.279s  INFO Compiling [ 15/225]: futures_core
-   9.279s  INFO Compiling [ 16/225]: memchr
-   9.280s  INFO Compiling [ 17/225]: futures_sink
-   9.280s  INFO Compiling [ 18/225]: unicode_xid
-   9.280s  INFO Compiling [ 19/225]: proc_macro2
-   9.280s  INFO Compiling [ 23/225]: build-script-build
-   9.280s  INFO Compiling [ 24/225]: build-script-build
-   9.280s  INFO Compiling [ 25/225]: tracing_core
-   9.280s  INFO Compiling [ 26/225]: futures_channel
-   9.280s  INFO Compiling [ 27/225]: build-script-build
-   9.280s  INFO Compiling [ 28/225]: futures_task
-   9.280s  INFO Compiling [ 29/225]: futures_io
-   9.280s  INFO Compiling [ 30/225]: pin_utils
-   9.280s  INFO Compiling [ 31/225]: scopeguard
-   9.280s  INFO Compiling [ 32/225]: stable_deref_trait
-   9.280s  INFO Compiling [ 33/225]: build-script-build
-   9.280s  INFO Compiling [ 34/225]: dioxus_core_types
-   9.280s  INFO Compiling [ 35/225]: build-script-build
-   9.281s  INFO Compiling [ 36/225]: rustc_hash
-   9.281s  INFO Compiling [ 37/225]: build-script-build
-   9.281s  INFO Compiling [ 38/225]: unicode_segmentation
-   9.281s  INFO Compiling [ 39/225]: longest_increasing_subsequence
-   9.281s  INFO Compiling [ 40/225]: lazy_js_bundle
-   9.281s  INFO Compiling [ 41/225]: fnv
-   9.281s  INFO Compiling [ 42/225]: ident_case
-   9.281s  INFO Compiling [ 43/225]: quote
-   9.281s  INFO Compiling [ 44/225]: wasm_bindgen_shared
-   9.281s  INFO Compiling [ 50/225]: convert_case
-   9.281s  INFO Compiling [ 51/225]: itoa
-   9.281s  INFO Compiling [ 52/225]: build-script-build
-   9.281s  INFO Compiling [ 53/225]: ryu
-   9.281s  INFO Compiling [ 54/225]: litemap
-   9.281s  INFO Compiling [ 55/225]: writeable
-   9.281s  INFO Compiling [ 57/225]: build-script-build
-   9.281s  INFO Compiling [ 58/225]: build-script-build
-   9.282s  INFO Compiling [ 59/225]: build-script-build
-   9.282s  INFO Compiling [ 61/225]: unicode_ident
-   9.282s  INFO Compiling [ 62/225]: bitflags
-   9.282s  INFO Compiling [ 63/225]: build-script-build
-   9.282s  INFO Compiling [ 64/225]: build-script-build
-   9.282s  INFO Compiling [ 65/225]: build-script-build
-   9.282s  INFO Compiling [ 66/225]: percent_encoding
-   9.282s  INFO Compiling [ 67/225]: syn
-   9.282s  INFO Compiling [ 68/225]: const_format_proc_macros
-   9.282s  INFO Compiling [ 69/225]: slab
-   9.282s  INFO Compiling [ 70/225]: parking_lot_core
-   9.282s  INFO Compiling [ 71/225]: lock_api
-   9.282s  INFO Compiling [ 72/225]: rustversion
-   9.282s  INFO Compiling [ 77/225]: proc_macro2
-   9.282s  INFO Compiling [ 78/225]: keyboard_types
-   9.282s  INFO Compiling [ 83/225]: utf8_iter
-   9.282s  INFO Compiling [ 84/225]: xxhash_rust
-   9.282s  INFO Compiling [ 85/225]: form_urlencoded
-   9.282s  INFO Compiling [ 86/225]: build-script-build
-   9.282s  INFO Compiling [ 87/225]: half
-   9.282s  INFO Compiling [ 88/225]: bytes
-   9.282s  INFO Compiling [ 89/225]: ciborium_io
-   9.283s  INFO Compiling [ 90/225]: lazy_static
-   9.283s  INFO Compiling [ 91/225]: serde_derive
-   9.283s  INFO Compiling [ 92/225]: wasm_bindgen_backend
-   9.283s  INFO Compiling [ 93/225]: synstructure
-   9.283s  INFO Compiling [ 94/225]: tracing_attributes
-   9.283s  INFO Compiling [ 95/225]: futures_macro
-   9.283s  INFO Compiling [ 96/225]: pin_project_internal
-   9.283s  INFO Compiling [ 97/225]: zerovec_derive
-   9.283s  INFO Compiling [ 98/225]: const_format
-   9.283s  INFO Compiling [ 99/225]: warnings_macro
-   9.283s  INFO Compiling [100/225]: displaydoc
-   9.283s  INFO Compiling [101/225]: parking_lot
-   9.283s  INFO Compiling [102/225]: darling_core
-   9.283s  INFO Compiling [103/225]: proc_macro2_diagnostics
-   9.283s  INFO Compiling [104/225]: num_traits
-   9.283s  INFO Compiling [105/225]: icu_normalizer_data
-   9.283s  INFO Compiling [106/225]: icu_properties_data
-   9.283s  INFO Compiling [107/225]: dioxus_html_internal_macro
-   9.283s  INFO Compiling [108/225]: async_trait
-   9.284s  INFO Compiling [109/225]: quote
-   9.284s  INFO Compiling [110/225]: const_serialize_macro
-   9.284s  INFO Compiling [111/225]: thiserror_impl
-   9.284s  INFO Compiling [112/225]: const_format
-   9.284s  INFO Compiling [113/225]: sledgehammer_bindgen_macro
-   9.284s  INFO Compiling [114/225]: build-script-build
-   9.284s  INFO Compiling [115/225]: wasm_bindgen_macro_support
-   9.284s  INFO Compiling [116/225]: serde
-   9.284s  INFO Compiling [117/225]: zerofrom_derive
-   9.284s  INFO Compiling [118/225]: yoke_derive
-   9.284s  INFO Compiling [119/225]: tracing
-   9.284s  INFO Compiling [120/225]: futures_util
-   9.284s  INFO Compiling [121/225]: pin_project
-   9.284s  INFO Compiling [122/225]: darling_macro
-   9.284s  INFO Compiling [123/225]: dioxus_rsx
-   9.284s  INFO Compiling [124/225]: euclid
-   9.284s  INFO Compiling [125/225]: syn
-   9.284s  INFO Compiling [126/225]: server_fn_macro
-   9.284s  INFO Compiling [127/225]: thiserror
-   9.285s  INFO Compiling [128/225]: serde
-   9.285s  INFO Compiling [129/225]: fnv
-   9.285s  INFO Compiling [132/225]: sharded_slab
-   9.285s  INFO Compiling [133/225]: ciborium_ll
-   9.285s  INFO Compiling [134/225]: zerocopy_derive
-   9.285s  INFO Compiling [135/225]: dioxus_config_macro
-   9.285s  INFO Compiling [137/225]: sledgehammer_utils
-   9.285s  INFO Compiling [138/225]: build-script-build
-   9.285s  INFO Compiling [139/225]: wasm_bindgen_macro
-   9.285s  INFO Compiling [140/225]: zerofrom
-   9.285s  INFO Compiling [141/225]: generational_box
-   9.285s  INFO Compiling [142/225]: warnings
-   9.285s  INFO Compiling [143/225]: slotmap
-   9.285s  INFO Compiling [144/225]: serde_json
-   9.285s  INFO Compiling [145/225]: darling
-   9.285s  INFO Compiling [146/225]: dioxus_core_macro
-   9.285s  INFO Compiling [147/225]: proc_macro2_diagnostics
-   9.285s  INFO Compiling [148/225]: const_serialize
-   9.286s  INFO Compiling [149/225]: futures_executor
-   9.286s  INFO Compiling [150/225]: http
-   9.286s  INFO Compiling [151/225]: thread_local
-   9.286s  INFO Compiling [152/225]: hashbrown
-   9.286s  INFO Compiling [153/225]: byteorder
-   9.286s  INFO Compiling [155/225]: serde_qs
-   9.286s  INFO Compiling [156/225]: server_fn_macro_default
-   9.286s  INFO Compiling [157/225]: const_serialize
-   9.286s  INFO Compiling [158/225]: slab
-   9.286s  INFO Compiling [159/225]: ciborium
-   9.286s  INFO Compiling [160/225]: send_wrapper
-   9.286s  INFO Compiling [161/225]: xxhash_rust
-   9.286s  INFO Compiling [162/225]: dioxus_server_macro
-   9.286s  INFO Compiling [163/225]: wasm_bindgen
-   9.286s  INFO Compiling [164/225]: yoke
-   9.286s  INFO Compiling [165/225]: dioxus_core
-   9.286s  INFO Compiling [166/225]: enumset_derive
-   9.287s  INFO Compiling [167/225]: dioxus_rsx
-   9.287s  INFO Compiling [168/225]: dashmap
-   9.287s  INFO Compiling [169/225]: zerocopy
-   9.287s  INFO Compiling [170/225]: manganis_core
-   9.287s  INFO Compiling [171/225]: futures
-   9.287s  INFO Compiling [172/225]: tracing_subscriber
-   9.287s  INFO Compiling [173/225]: dioxus_router_macro
-   9.287s  INFO Compiling [174/225]: base64
-   9.287s  INFO Compiling [175/225]: urlencoding
-   9.287s  INFO Compiling [176/225]: either
-   9.287s  INFO Compiling [177/225]: js_sys
-   9.287s  INFO Compiling [178/225]: zerovec
-   9.287s  INFO Compiling [179/225]: zerotrie
-   9.287s  INFO Compiling [180/225]: dioxus_signals
-   9.287s  INFO Compiling [181/225]: enumset
-   9.287s  INFO Compiling [182/225]: dioxus_cli_config
-   9.287s  INFO Compiling [183/225]: dioxus_history
-   9.288s  INFO Compiling [184/225]: dioxus_devtools_types
-   9.288s  INFO Compiling [185/225]: sledgehammer_bindgen
-   9.288s  INFO Compiling [186/225]: console_error_panic_hook
-   9.288s  INFO Compiling [187/225]: tracing_wasm
-   9.288s  INFO Compiling [188/225]: manganis_macro
-   9.288s  INFO Compiling [189/225]: ppv_lite86
-   9.288s  INFO Compiling [190/225]: itertools
-   9.288s  INFO Compiling [191/225]: tinystr
-   9.288s  INFO Compiling [192/225]: potential_utf
-   9.288s  INFO Compiling [193/225]: dioxus_hooks
-   9.288s  INFO Compiling [194/225]: wasm_bindgen_futures
-   9.288s  INFO Compiling [195/225]: serde_wasm_bindgen
-   9.288s  INFO Compiling [196/225]: getrandom
-   9.288s  INFO Compiling [197/225]: dioxus_devtools
-   9.289s  INFO Compiling [198/225]: manganis_core
-   9.289s  INFO Compiling [199/225]: dioxus_logger
-   9.289s  INFO Compiling [200/225]: icu_locale_core
-   9.289s  INFO Compiling [201/225]: icu_collections
-   9.289s  INFO Compiling [202/225]: dioxus_html
-   9.289s  INFO Compiling [203/225]: rand_core
-   9.289s  INFO Compiling [204/225]: manganis
-   9.289s  INFO Compiling [205/225]: icu_provider
-   9.289s  INFO Compiling [206/225]: dioxus_document
-   9.289s  INFO Compiling [207/225]: rand_chacha
-   9.289s  INFO Compiling [208/225]: icu_properties
-   9.289s  INFO Compiling [209/225]: icu_normalizer
-   9.289s  INFO Compiling [210/225]: dioxus_lib
-   9.289s  INFO Compiling [211/225]: rand
-   9.290s  INFO Compiling [212/225]: idna_adapter
-   9.290s  INFO Compiling [213/225]: idna
-   9.290s  INFO Compiling [214/225]: url
-   9.290s  INFO Compiling [215/225]: dioxus_router
-  14.770s  INFO Compiling [216/225]: gloo_utils
-  15.61s  INFO Compiling [217/225]: web_sys
-  15.122s  INFO Compiling [218/225]: gloo_net
-  15.394s  INFO Compiling [219/225]: dioxus_interpreter_js
-  15.492s  INFO Compiling [220/225]: wasm_streams
-  15.706s  INFO Compiling [221/225]: server_fn
-  15.893s  INFO Compiling [222/225]: dioxus
-  15.946s  INFO Compiling [223/225]: dioxus_fullstack
-  16.142s  INFO Compiling [224/225]: dioxus_web
-  18.718s  INFO Bundling app...
-  18.718s  INFO Running wasm-bindgen...
-  18.946s  INFO Copying asset (0/32): /var/www/html/assets/images/ogp/base_endecode_converter.webp
-  18.946s  INFO Copying asset (1/32): /var/www/html/assets/images/ogp/password_generator.webp
-  18.946s  INFO Copying asset (2/32): /var/www/html/assets/images/ogp/url_endecode_converter.webp
-  18.947s  INFO Copying asset (3/32): /var/www/html/assets/images/ogp/text_length_counter.webp
-  18.947s  INFO Copying asset (4/32): /var/www/html/assets/images/icons/big_numbers_calculator.webp
-  18.947s  INFO Copying asset (5/32): /var/www/html/assets/images/logos/app_logo.webp
-  18.947s  INFO Copying asset (7/32): /var/www/html/assets/images/icons/text_length_counter.webp
-  18.947s  INFO Copying asset (10/32): /var/www/html/assets/images/ogp/byte_unit_calculator.webp
-  18.947s  INFO Copying asset (6/32): /var/www/html/assets/images/icons/simple_calculator.webp
-  18.948s  INFO Copying asset (8/32): /var/www/html/assets/images/icons/byte_unit_calculator.webp
-  18.948s  INFO Copying asset (9/32): /var/www/html/assets/images/ogp/top.webp
-  18.948s  INFO Copying asset (11/32): /var/www/html/assets/images/icons/url_endecode_converter.webp
-  18.948s  INFO Copying asset (14/32): /var/www/html/assets/images/icons/base_endecode_converter.webp
-  18.948s  INFO Copying asset (15/32): /var/www/html/assets/images/icons/password_generator.webp
-  18.948s  INFO Copying asset (16/32): /var/www/html/assets/images/ogp/big_numbers_calculator.webp
-  18.948s  INFO Copying asset (12/32): /var/www/html/assets/material-icons/content_copy/22dp_434343_FILL0_wght400_GRAD0_opsz20.svg
-  18.948s  INFO Copying asset (13/32): /var/www/html/assets/images/icons/number_base_converter.webp
-  18.953s  INFO Copying asset (18/32): /var/www/html/assets/images/ogp/err_404.webp
-  18.953s  INFO Copying asset (17/32): /var/www/html/assets/images/ogp/number_base_converter.webp
-  18.953s  INFO Copying asset (19/32): /var/www/html/assets/favicon.ico
-  18.954s  INFO Copying asset (20/32): /var/www/html/assets/manifest.webmanifest
-  18.957s  INFO Copying asset (21/32): /var/www/html/assets/material-icons
-  18.957s  INFO Copying asset (22/32): /var/www/html/assets/icon-192.png
-  18.957s  INFO Copying asset (23/32): /var/www/html/assets/apple-touch-icon.png
-  18.957s  INFO Copying asset (24/32): /var/www/html/target/dx/WebTools/release/web/public/wasm-bindgen/WebTools_bg.wasm
-  18.957s  INFO Copying asset (25/32): /var/www/html/assets/tailwind.css
-  18.958s  INFO Copying asset (26/32): /var/www/html/assets/tailwind.css
-  18.958s  INFO Copying asset (27/32): /var/www/html/assets/icon-512.png
-  18.958s  INFO Copying asset (28/32): /var/www/html/assets/images/ogp/json_formatter.webp
-  18.958s  INFO Copying asset (29/32): /var/www/html/assets/images/icons/json_formatter.webp
-  18.973s  INFO Copying asset (30/32): /var/www/html/target/dx/WebTools/release/web/public/wasm-bindgen/WebTools.js
-  19.17s  INFO Copying asset (31/32): /var/www/html/assets/images
-  23.685s  INFO Running SSG at http://127.0.0.1:9999
-  23.717s  INFO Rendering / for SSG
-  23.717s  INFO Rendering /generator/password for SSG
-  23.717s  INFO Rendering /counter/text-length for SSG
-  23.717s  INFO Rendering /converter/base-endecode for SSG
-  23.717s  INFO Rendering /converter/number-base for SSG
-  23.717s  INFO Rendering /converter/url-endecode for SSG
-  23.717s  INFO Rendering /calculator/byte-unit for SSG
-  23.717s  INFO Rendering /calculator/simple for SSG
-  23.717s  INFO Rendering /calculator/big-numbers for SSG
-  23.718s  INFO Rendering /formatter/json for SSG
-  23.718s  INFO Rendering /404 for SSG
-  23.776s  INFO SSG complete
-  23.777s  INFO Copying bundles to output directory: /var/www/html/dist
-  23.791s  INFO Bundled app at: /var/www/html/dist/server
-  23.791s  INFO Bundled app at: /var/www/html/dist/public
-アプリケーション bundle 成功
-クリーンアップ（開発環境の復元）を実行中...
-元のCargo.tomlを復元中...
-クリーンアップ完了（開発環境の復元完了）
+    Checking WebTools v0.1.0 (/home/pr0gr/RustroverProjects/WebTools/web)
+warning: variables can be used directly in the `format!` string
+  --> src/components/errors/err_404.rs:19:24
+   |
+19 |     let title: &str = &format!("404 Not Found - {}", APP_TITLE);
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+   = note: `#[warn(clippy::uninlined_format_args)]` on by default
+help: change this to
+   |
+19 -     let title: &str = &format!("404 Not Found - {}", APP_TITLE);
+19 +     let title: &str = &format!("404 Not Found - {APP_TITLE}");
+   |
+warning: variables can be used directly in the `format!` string
+  --> src/libs/base.rs:18:21
+   |
+18 |         .map(|byte| format!("{:02x}", byte))
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+18 -         .map(|byte| format!("{:02x}", byte))
+18 +         .map(|byte| format!("{byte:02x}"))
+   |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/base.rs:219:28
+    |
+219 | ...   return Err(format!("Base64デコードエラー: 無効な文字 '{}'", c));
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+219 -                 return Err(format!("Base64デコードエラー: 無効な文字 '{}'", c));
+219 +                 return Err(format!("Base64デコードエラー: 無効な文字 '{c}'"));
+    |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/calculator/big_numbers.rs:109:29
+    |
+109 |         let a_frac_padded = format!("{:0<20}", a_frac);
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+109 -         let a_frac_padded = format!("{:0<20}", a_frac);
+109 +         let a_frac_padded = format!("{a_frac:0<20}");
+    |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/calculator/big_numbers.rs:110:29
+    |
+110 |         let b_frac_padded = format!("{:0<20}", b_frac);
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+110 -         let b_frac_padded = format!("{:0<20}", b_frac);
+110 +         let b_frac_padded = format!("{b_frac:0<20}");
+    |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/calculator/big_numbers.rs:206:25
+    |
+206 | ...added = format!("{:0<width$}", a_frac, width = max_frac_len);
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+206 -     let a_frac_padded = format!("{:0<width$}", a_frac, width = max_frac_len);
+206 +     let a_frac_padded = format!("{a_frac:0<max_frac_len$}");
+    |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/calculator/big_numbers.rs:207:25
+    |
+207 | ...added = format!("{:0<width$}", b_frac, width = max_frac_len);
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+207 -     let b_frac_padded = format!("{:0<width$}", b_frac, width = max_frac_len);
+207 +     let b_frac_padded = format!("{b_frac:0<max_frac_len$}");
+    |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/calculator/big_numbers.rs:606:25
+    |
+606 | ...added = format!("{:0<width$}", a_frac, width = max_frac_len);
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+606 -     let a_frac_padded = format!("{:0<width$}", a_frac, width = max_frac_len);
+606 +     let a_frac_padded = format!("{a_frac:0<max_frac_len$}");
+    |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/calculator/big_numbers.rs:607:25
+    |
+607 | ...added = format!("{:0<width$}", b_frac, width = max_frac_len);
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+607 -     let b_frac_padded = format!("{:0<width$}", b_frac, width = max_frac_len);
+607 +     let b_frac_padded = format!("{b_frac:0<max_frac_len$}");
+    |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/calculator/big_numbers.rs:643:33
+    |
+643 |                 _ => return Err(format!("Unknown operator: {}", token)),
+    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+643 -                 _ => return Err(format!("Unknown operator: {}", token)),
+643 +                 _ => return Err(format!("Unknown operator: {token}")),
+    |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/calculator/big_numbers.rs:716:29
+    |
+716 |             _ => return Err(format!("Invalid character: {}", c)),
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+716 -             _ => return Err(format!("Invalid character: {}", c)),
+716 +             _ => return Err(format!("Invalid character: {c}")),
+    |
+warning: variables can be used directly in the `format!` string
+  --> src/libs/calculator/byte_unit.rs:25:25
+   |
+25 |         _ => return Err(format!("Unknown unit: {}", unit)),
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+25 -         _ => return Err(format!("Unknown unit: {}", unit)),
+25 +         _ => return Err(format!("Unknown unit: {unit}")),
+   |
+warning: variables can be used directly in the `format!` string
+  --> src/libs/calculator/byte_unit.rs:29:8
+   |
+29 |     Ok(format!("{:.10}", result)
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+29 -     Ok(format!("{:.10}", result)
+29 +     Ok(format!("{result:.10}")
+   |
+warning: variables can be used directly in the `format!` string
+  --> src/libs/calculator/byte_unit.rs:57:25
+   |
+57 |         _ => return Err(format!("Unknown unit: {}", unit)),
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+57 -         _ => return Err(format!("Unknown unit: {}", unit)),
+57 +         _ => return Err(format!("Unknown unit: {unit}")),
+   |
+warning: variables can be used directly in the `format!` string
+  --> src/libs/calculator/byte_unit.rs:61:8
+   |
+61 |     Ok(format!("{:.0}", bytes))
+   |        ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+61 -     Ok(format!("{:.0}", bytes))
+61 +     Ok(format!("{bytes:.0}"))
+   |
+warning: variables can be used directly in the `format!` string
+  --> src/libs/calculator/simple.rs:97:33
+   |
+97 |                 _ => return Err(format!("Unknown operator: {}", token)),
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+97 -                 _ => return Err(format!("Unknown operator: {}", token)),
+97 +                 _ => return Err(format!("Unknown operator: {token}")),
+   |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/calculator/simple.rs:156:32
+    |
+156 |                     return Err(format!("Invalid character: {}", c));
+    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+156 -                     return Err(format!("Invalid character: {}", c));
+156 +                     return Err(format!("Invalid character: {c}"));
+    |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/calculator/simple.rs:198:29
+    |
+198 |             _ => return Err(format!("Invalid character: {}", c)),
+    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+198 -             _ => return Err(format!("Invalid character: {}", c)),
+198 +             _ => return Err(format!("Invalid character: {c}")),
+    |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/calculator/simple.rs:225:17
+    |
+225 |                 format!("{:e}", value)
+    |                 ^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+225 -                 format!("{:e}", value)
+225 +                 format!("{value:e}")
+    |
+warning: variables can be used directly in the `format!` string
+  --> src/libs/number.rs:16:20
+   |
+16 |   ...   return Err(format!(
+   |  __________________^
+17 | | ...       "進数は2から36の間である必要があります。指定された進数: {}",
+18 | | ...       base
+19 | | ...   ));
+   | |_______^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+warning: variables can be used directly in the `format!` string
+  --> src/libs/number.rs:60:20
+   |
+60 |   ...   return Err(format!(
+   |  __________________^
+61 | | ...       "進数は2から36の間である必要があります。指定された進数: {}",
+62 | | ...       base
+63 | | ...   ));
+   | |_______^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+warning: variables can be used directly in the `format!` string
+  --> src/libs/number.rs:79:32
+   |
+79 | ...   None => return Err(format!("無効な文字が含まれています: {}", c)),
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+79 -             None => return Err(format!("無効な文字が含まれています: {}", c)),
+79 +             None => return Err(format!("無効な文字が含まれています: {c}")),
+   |
+warning: variables can be used directly in the `format!` string
+  --> src/libs/number.rs:84:24
+   |
+84 | ...   return Err(format!("文字 '{}' は{}進数では使用できません", c, base));
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+84 -             return Err(format!("文字 '{}' は{}進数では使用できません", c, base));
+84 +             return Err(format!("文字 '{c}' は{base}進数では使用できません"));
+   |
+warning: variables can be used directly in the `format!` string
+   --> src/libs/url.rs:104:17
+    |
+104 |                 format!("{}={}", k, v)
+    |                 ^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+104 -                 format!("{}={}", k, v)
+104 +                 format!("{k}={v}")
+    |
+warning: variables can be used directly in the `format!` string
+  --> src/routes/converter/url_endecode.rs:59:43
+   |
+59 | ...   Err(err) => error_message.set(format!("デコードエラー: {}", err)),
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+59 -             Err(err) => error_message.set(format!("デコードエラー: {}", err,
+59 +             Err(err) => error_message.set(format!("デコードエラー: {err}")),
+   |
+warning: variables can be used directly in the `format!` string
+  --> src/routes/formatter/json.rs:76:17
+   |
+76 |                 format!("JSON構文エラー: {}", e),
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+76 -                 format!("JSON構文エラー: {}", e),
+76 +                 format!("JSON構文エラー: {e}"),
+   |
+warning: variables can be used directly in the `format!` string
+   --> src/routes/formatter/json.rs:167:42
+    |
+167 | ...   copy_success.set(format!("{}をクリップボードにコピーしました", field_name))
+    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+167 -                         copy_success.set(format!("{}をクリップボードにコピld_name))
+167 +                         copy_success.set(format!("{field_name}をクリップボしました"))
+    |
+warning: variables can be used directly in the `format!` string
+   --> src/routes/generator/password.rs:430:55
+    |
+430 | ...et(format!("パスワードの長さは {} ~ {} 以下である必要があります", min_length, max_length));
+    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+430 -                                     error_message.set(format!("パスワードの} ~ {} 以下である必要があります", min_length, max_length));
+430 +                                     error_message.set(format!("パスワードのmin_length} ~ {max_length} 以下である必要があります"));
+    |
+warning: variables can be used directly in the `format!` string
+   --> src/routes/generator/password.rs:435:55
+    |
+435 | ...et(format!("生成するパスワードの数は {} ~ {} 以下である必要があります", min_qty, max_qty));
+    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+435 -                                     error_message.set(format!("生成するパスは {} ~ {} 以下である必要があります", min_qty, max_qty));
+435 +                                     error_message.set(format!("生成するパスは {min_qty} ~ {max_qty} 以下である必要があります"));
+    |
+warning: `WebTools` (bin "WebTools") generated 29 warnings (run `cargo clippy --fix --bin "WebTools"` to apply 29 suggestions)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.95s

--- a/web/src/components/breadcrumb.rs
+++ b/web/src/components/breadcrumb.rs
@@ -49,6 +49,7 @@ pub(crate) fn BreadcrumbList(props: BreadcrumbListProps) -> Element {
                     BreadcrumbItemElement {
                         name: item.name.clone(),
                         to: item.to.clone(),
+                        position: index + 1,
                     }
 
                     if index != props.items.len() - 1 {
@@ -68,33 +69,52 @@ pub(crate) fn BreadcrumbList(props: BreadcrumbListProps) -> Element {
 /// # Arguments
 ///
 /// * `props` - `BreadcrumbItem` パンくずリストのアイテム構造体
+/// * `position` - `usize` パンくずリスト内での位置（1から開始）
 ///
 /// # Fields
 ///
 /// * `name` - `String` 表示する要素名
 /// * `to` - `Option<Route>` たどってきたページのリンク
-fn BreadcrumbItemElement(props: BreadcrumbItem) -> Element {
+/// * `position` - `usize` パンくずリスト内での位置
+#[derive(PartialEq, Clone, Props)]
+struct BreadcrumbItemElementProps {
+    name: String,
+    to: Option<Route>,
+    position: usize,
+}
+
+fn BreadcrumbItemElement(props: BreadcrumbItemElementProps) -> Element {
     rsx! {
         li {
             itemprop: "itemListElement",
             itemscope: true,
             itemtype: "https://schema.org/ListItem",
 
+            // Use meta tag for position, which is cleaner for non-visible data
+            meta {
+                itemprop: "position",
+                content: "{props.position}"
+            }
+
             if let Some(to) = props.to {
+                // For links, the <a> tag is the "item" (the URL) and the text inside is the "name"
                 Link {
                     to: to,
                     class: "self-center text-blue-400 text-xs",
-
-                    {props.name.clone()}
+                    itemprop: "item",
+                    span {
+                        itemprop: "name",
+                        {props.name.clone()}
+                    }
                 }
             } else {
+                // For the current page (not a link), we only provide the "name"
                 span {
                     class: "self-center text-xs",
+                    itemprop: "name",
                     {props.name.clone()}
                 }
             }
-
-            // meta タグは現状 head タグに行ってしまうため配置しない
         }
     }
 }

--- a/web/src/components/breadcrumb.rs
+++ b/web/src/components/breadcrumb.rs
@@ -38,6 +38,7 @@ pub(crate) struct BreadcrumbItem {
 pub(crate) fn BreadcrumbList(props: BreadcrumbListProps) -> Element {
     rsx! {
         ol {
+            "aria-label": "breadcrumb",
             itemtype: "https://schema.org/BreadcrumbList",
             itemscope: true,
             class: "flex pt-[-2rem]",
@@ -47,6 +48,7 @@ pub(crate) fn BreadcrumbList(props: BreadcrumbListProps) -> Element {
                 .enumerate()
                 .map(|(index, item)| rsx! {
                     BreadcrumbItemElement {
+                        key: "{item.name}",
                         name: item.name.clone(),
                         to: item.to.clone(),
                         position: index + 1,
@@ -54,6 +56,7 @@ pub(crate) fn BreadcrumbList(props: BreadcrumbListProps) -> Element {
 
                     if index != props.items.len() - 1 {
                         span {
+                            "aria-hidden": "true",
                             class: "relative self-center top-[1px] mx-2 text-xs",
                             ">"
                         }

--- a/web/src/components/breadcrumb.rs
+++ b/web/src/components/breadcrumb.rs
@@ -96,7 +96,7 @@ fn BreadcrumbItemElement(props: BreadcrumbItemElementProps) -> Element {
             // Use meta tag for position, which is cleaner for non-visible data
             meta {
                 itemprop: "position",
-                content: "{props.position}"
+                content: "{props.position.to_string()}"
             }
 
             if let Some(to) = props.to {


### PR DESCRIPTION
Google Search Consoleで報告されていたパンくずリストの構造化データエラーを修正しました。「name」または「item.name」フィールドの不足と「position」フィールドの欠如を解決し、Schema.orgのBreadcrumbList仕様に準拠するよう実装を改善しました。